### PR TITLE
BREAKING: Rename solax_x1 to solax_x1_mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# esphome-modbus-solax-x1
+# esphome-solax-x1-mini
 
-![GitHub actions](https://github.com/syssi/esphome-modbus-solax-x1/actions/workflows/ci.yaml/badge.svg)
-![GitHub stars](https://img.shields.io/github/stars/syssi/esphome-modbus-solax-x1)
-![GitHub forks](https://img.shields.io/github/forks/syssi/esphome-modbus-solax-x1)
-![GitHub watchers](https://img.shields.io/github/watchers/syssi/esphome-modbus-solax-x1)
+![GitHub actions](https://github.com/syssi/esphome-solax-x1-mini/actions/workflows/ci.yaml/badge.svg)
+![GitHub stars](https://img.shields.io/github/stars/syssi/esphome-solax-x1-mini)
+![GitHub forks](https://img.shields.io/github/forks/syssi/esphome-solax-x1-mini)
+![GitHub watchers](https://img.shields.io/github/watchers/syssi/esphome-solax-x1-mini)
 [!["Buy Me A Coffee"](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg)](https://www.buymeacoffee.com/syssi)
 
 ESPHome component to monitor a Solax X1 mini via RS485.
@@ -15,10 +15,10 @@ ESPHome component to monitor a Solax X1 mini via RS485.
 * SolaX X1 Mini
   - SolaX X1 Mini X1-0.6-S-D(L)
 * SolaX X1 Mini G2
-  - SolaX X1 Mini X1-1.5-S-D(L) (master version 1.08, manager version 1.07) (reported by [@beocycris](https://github.com/syssi/esphome-modbus-solax-x1/issues/18#issuecomment-1073188868))
-  - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@zcloud-at](https://github.com/syssi/esphome-modbus-solax-x1/issues/15))
+  - SolaX X1 Mini X1-1.5-S-D(L) (master version 1.08, manager version 1.07) (reported by [@beocycris](https://github.com/syssi/esphome-solax-x1-mini/issues/18#issuecomment-1073188868))
+  - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@zcloud-at](https://github.com/syssi/esphome-solax-x1-mini/issues/15))
 * SolaX X1 Mini G3
-  - SolaX X1 Mini X1-0.6-S-D(L) (master version 1.08, manager version 1.07) (reported by [@neujbit](https://github.com/syssi/esphome-modbus-solax-x1/issues/22))
+  - SolaX X1 Mini X1-0.6-S-D(L) (master version 1.08, manager version 1.07) (reported by [@neujbit](https://github.com/syssi/esphome-solax-x1-mini/issues/22))
 
 ## Requirements
 
@@ -79,7 +79,7 @@ Please make sure to power the RS485 module with 3.3V because it affects the TTL 
 You can install this component with [ESPHome external components feature](https://esphome.io/components/external_components.html) like this:
 ```yaml
 external_components:
-  - source: github://syssi/esphome-modbus-solax-x1@main
+  - source: github://syssi/esphome-solax-x1-mini@main
 ```
 
 or just use the `esp32-example.yaml` / `esp8266-example.yaml` as proof of concept:
@@ -89,8 +89,8 @@ or just use the `esp32-example.yaml` / `esp8266-example.yaml` as proof of concep
 pip3 install esphome
 
 # Clone this external component
-git clone https://github.com/syssi/esphome-modbus-solax-x1.git
-cd esphome-modbus-solax-x1
+git clone https://github.com/syssi/esphome-solax-x1-mini.git
+cd esphome-solax-x1-mini
 
 # Create a secrets.yaml containing some setup specific secrets
 cat > secrets.yaml <<EOF
@@ -120,7 +120,7 @@ esphome:
   board: esp-wrover-kit
 
 external_components:
-  - source: github://syssi/esphome-modbus-solax-x1@main
+  - source: github://syssi/esphome-solax-x1-mini@main
     refresh: 0s
 
 wifi:
@@ -148,18 +148,18 @@ uart:
 solax_modbus:
 #   flow_control_pin: GPIO0
 
-solax_x1:
+solax_x1_mini:
   update_interval: 1s
 
 text_sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     mode_name:
       name: "${name} mode name"
     errors:
       name: "${name} errors"
 
 sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     ac_power:
       name: "${name} ac power"
     energy_today:
@@ -304,4 +304,4 @@ Data 50...52 (ct pgrid):           0x02 0xD0 (720 W)
 * https://github.com/JensJordan/solaXd/
 * https://github.com/arendst/Tasmota/blob/development/tasmota/xnrg_12_solaxX1.ino
 * https://github.com/esphome/esphome/blob/dev/esphome/components/modbus/modbus.cpp
-* https://github.com/syssi/esphome-modbus-solax-x1/blob/main/docs/SolaxPower_Single_Phase_External_Communication_Protocol_-_X1_Series_V1.2.pdf
+* https://github.com/syssi/esphome-solax-x1-mini/blob/main/docs/SolaxPower_Single_Phase_External_Communication_Protocol_-_X1_Series_V1.2.pdf

--- a/components/solax_x1_mini/__init__.py
+++ b/components/solax_x1_mini/__init__.py
@@ -7,15 +7,15 @@ AUTO_LOAD = ["solax_modbus", "sensor", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
-CONF_SOLAX_X1_ID = "solax_x1_id"
+CONF__SOLAX_X1_MINI_ID = "solax_x1_mini_id"
 
-solax_x1_ns = cg.esphome_ns.namespace("solax_x1")
-SolaxX1 = solax_x1_ns.class_(
-    "SolaxX1", cg.PollingComponent, solax_modbus.SolaxModbusDevice
+solax_x1_mini_ns = cg.esphome_ns.namespace("solax_x1_mini")
+SolaxX1Mini = solax_x1_mini_ns.class_(
+    "SolaxX1Mini", cg.PollingComponent, solax_modbus.SolaxModbusDevice
 )
 
 CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(SolaxX1)})
+    cv.Schema({cv.GenerateID(): cv.declare_id(SolaxX1Mini)})
     .extend(cv.polling_component_schema("30s"))
     .extend(
         solax_modbus.solax_modbus_device_schema(0x0A, "3132333435363737363534333231")

--- a/components/solax_x1_mini/__init__.py
+++ b/components/solax_x1_mini/__init__.py
@@ -7,7 +7,7 @@ AUTO_LOAD = ["solax_modbus", "sensor", "text_sensor"]
 CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
-CONF__SOLAX_X1_MINI_ID = "solax_x1_mini_id"
+CONF_SOLAX_X1_MINI_ID = "solax_x1_mini_id"
 
 solax_x1_mini_ns = cg.esphome_ns.namespace("solax_x1_mini")
 SolaxX1Mini = solax_x1_mini_ns.class_(

--- a/components/solax_x1_mini/sensor.py
+++ b/components/solax_x1_mini/sensor.py
@@ -24,7 +24,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF__SOLAX_X1_MINI_ID, SolaxX1Mini
+from . import CONF_SOLAX_X1_MINI_ID, SolaxX1Mini
 
 DEPENDENCIES = ["solax_x1_mini"]
 
@@ -74,7 +74,7 @@ SENSORS = [
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF__SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
+        cv.GenerateID(CONF_SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
         cv.Optional(CONF_ENERGY_TODAY): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILO_WATT_HOURS,
             icon=ICON_COUNTER,
@@ -210,7 +210,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    hub = await cg.get_variable(config[CONF__SOLAX_X1_MINI_ID])
+    hub = await cg.get_variable(config[CONF_SOLAX_X1_MINI_ID])
     for key in SENSORS:
         if key in config:
             conf = config[key]

--- a/components/solax_x1_mini/sensor.py
+++ b/components/solax_x1_mini/sensor.py
@@ -24,9 +24,9 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_SOLAX_X1_ID, SolaxX1
+from . import CONF__SOLAX_X1_MINI_ID, SolaxX1Mini
 
-DEPENDENCIES = ["solax_x1"]
+DEPENDENCIES = ["solax_x1_mini"]
 
 CONF_ENERGY_TODAY = "energy_today"
 CONF_ENERGY_TOTAL = "energy_total"
@@ -74,7 +74,7 @@ SENSORS = [
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_SOLAX_X1_ID): cv.use_id(SolaxX1),
+        cv.GenerateID(CONF__SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
         cv.Optional(CONF_ENERGY_TODAY): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILO_WATT_HOURS,
             icon=ICON_COUNTER,
@@ -210,7 +210,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    hub = await cg.get_variable(config[CONF_SOLAX_X1_ID])
+    hub = await cg.get_variable(config[CONF__SOLAX_X1_MINI_ID])
     for key in SENSORS:
         if key in config:
             conf = config[key]

--- a/components/solax_x1_mini/solax_x1_mini.cpp
+++ b/components/solax_x1_mini/solax_x1_mini.cpp
@@ -1,10 +1,10 @@
-#include "solax_x1.h"
+#include "solax_x1_mini.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace solax_x1 {
+namespace solax_x1_mini {
 
-static const char *const TAG = "solax_x1";
+static const char *const TAG = "solax_x1_mini";
 
 static const uint8_t FUNCTION_STATUS_REPORT = 0x82;
 static const uint8_t FUNCTION_DEVICE_INFO = 0x83;
@@ -60,7 +60,7 @@ static const char *const ERRORS[ERRORS_SIZE] = {
     "Error (Bit 31)",                            // 1000 0000 0000 0000 0000 0000 0000 0000 (32)
 };
 
-void SolaxX1::on_solax_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) {
+void SolaxX1Mini::on_solax_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) {
   switch (function) {
     case FUNCTION_DEVICE_INFO:
       this->decode_device_info_(data);
@@ -76,7 +76,7 @@ void SolaxX1::on_solax_modbus_data(const uint8_t &function, const std::vector<ui
   }
 }
 
-void SolaxX1::decode_device_info_(const std::vector<uint8_t> &data) {
+void SolaxX1Mini::decode_device_info_(const std::vector<uint8_t> &data) {
   if (data.size() != 58) {
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
     return;
@@ -94,7 +94,7 @@ void SolaxX1::decode_device_info_(const std::vector<uint8_t> &data) {
   this->no_response_count_ = 0;
 }
 
-void SolaxX1::decode_config_settings_(const std::vector<uint8_t> &data) {
+void SolaxX1Mini::decode_config_settings_(const std::vector<uint8_t> &data) {
   if (data.size() != 68) {
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
     return;
@@ -190,7 +190,7 @@ void SolaxX1::decode_config_settings_(const std::vector<uint8_t> &data) {
   this->no_response_count_ = 0;
 }
 
-void SolaxX1::decode_status_report_(const std::vector<uint8_t> &data) {
+void SolaxX1Mini::decode_status_report_(const std::vector<uint8_t> &data) {
   if (data.size() != 52 && data.size() != 50 && data.size() != 56) {
     // Solax X1 mini status report (data_len 0x34: 52 bytes):
     // AA.55.00.0A.01.00.11.82.34.00.1A.00.02.00.00.00.00.00.00.00.00.00.00.09.21.13.87.00.00.FF.FF.
@@ -270,7 +270,7 @@ void SolaxX1::decode_status_report_(const std::vector<uint8_t> &data) {
   this->no_response_count_ = 0;
 }
 
-void SolaxX1::publish_device_offline_() {
+void SolaxX1Mini::publish_device_offline_() {
   this->publish_state_(this->mode_sensor_, -1);
   this->publish_state_(this->mode_name_text_sensor_, "Offline");
 
@@ -292,7 +292,7 @@ void SolaxX1::publish_device_offline_() {
   this->publish_state_(this->gfc_fault_sensor_, NAN);
 }
 
-void SolaxX1::update() {
+void SolaxX1Mini::update() {
   if (this->no_response_count_ >= REDISCOVERY_THRESHOLD) {
     this->publish_device_offline_();
     ESP_LOGD(TAG, "The device is or was offline. Broadcasting discovery for address configuration...");
@@ -307,22 +307,22 @@ void SolaxX1::update() {
   }
 }
 
-void SolaxX1::publish_state_(sensor::Sensor *sensor, float value) {
+void SolaxX1Mini::publish_state_(sensor::Sensor *sensor, float value) {
   if (sensor == nullptr)
     return;
 
   sensor->publish_state(value);
 }
 
-void SolaxX1::publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state) {
+void SolaxX1Mini::publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state) {
   if (text_sensor == nullptr)
     return;
 
   text_sensor->publish_state(state);
 }
 
-void SolaxX1::dump_config() {
-  ESP_LOGCONFIG(TAG, "SolaxX1:");
+void SolaxX1Mini::dump_config() {
+  ESP_LOGCONFIG(TAG, "SolaxX1Mini:");
   ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
   LOG_SENSOR("", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("", "Energy today", this->energy_today_sensor_);
@@ -349,7 +349,7 @@ void SolaxX1::dump_config() {
   LOG_TEXT_SENSOR("  ", "Errors", this->errors_text_sensor_);
 }
 
-std::string SolaxX1::error_bits_to_string_(const uint32_t mask) {
+std::string SolaxX1Mini::error_bits_to_string_(const uint32_t mask) {
   std::string values = "";
   if (mask) {
     for (int i = 0; i < ERRORS_SIZE; i++) {
@@ -365,5 +365,5 @@ std::string SolaxX1::error_bits_to_string_(const uint32_t mask) {
   return values;
 }
 
-}  // namespace solax_x1
+}  // namespace solax_x1_mini
 }  // namespace esphome

--- a/components/solax_x1_mini/solax_x1_mini.h
+++ b/components/solax_x1_mini/solax_x1_mini.h
@@ -6,11 +6,11 @@
 #include "esphome/components/solax_modbus/solax_modbus.h"
 
 namespace esphome {
-namespace solax_x1 {
+namespace solax_x1_mini {
 
 static const uint8_t REDISCOVERY_THRESHOLD = 5;
 
-class SolaxX1 : public PollingComponent, public solax_modbus::SolaxModbusDevice {
+class SolaxX1Mini : public PollingComponent, public solax_modbus::SolaxModbusDevice {
  public:
   void set_energy_today_sensor(sensor::Sensor *energy_today_sensor) { energy_today_sensor_ = energy_today_sensor; }
   void set_energy_total_sensor(sensor::Sensor *energy_total_sensor) { energy_total_sensor_ = energy_total_sensor; }
@@ -90,5 +90,5 @@ class SolaxX1 : public PollingComponent, public solax_modbus::SolaxModbusDevice 
   std::string error_bits_to_string_(uint32_t bitmask);
 };
 
-}  // namespace solax_x1
+}  // namespace solax_x1_mini
 }  // namespace esphome

--- a/components/solax_x1_mini/text_sensor.py
+++ b/components/solax_x1_mini/text_sensor.py
@@ -3,7 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID
 
-from . import CONF__SOLAX_X1_MINI_ID, SolaxX1Mini
+from . import CONF_SOLAX_X1_MINI_ID, SolaxX1Mini
 
 DEPENDENCIES = ["solax_x1_mini"]
 
@@ -15,7 +15,7 @@ ICON_ERRORS = "mdi:alert-circle-outline"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF__SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
+        cv.GenerateID(CONF_SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
         cv.Optional(CONF_MODE_NAME): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    hub = await cg.get_variable(config[CONF__SOLAX_X1_MINI_ID])
+    hub = await cg.get_variable(config[CONF_SOLAX_X1_MINI_ID])
     for key in [CONF_MODE_NAME, CONF_ERRORS]:
         if key in config:
             conf = config[key]

--- a/components/solax_x1_mini/text_sensor.py
+++ b/components/solax_x1_mini/text_sensor.py
@@ -3,9 +3,9 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ICON, CONF_ID
 
-from . import CONF_SOLAX_X1_ID, SolaxX1
+from . import CONF__SOLAX_X1_MINI_ID, SolaxX1Mini
 
-DEPENDENCIES = ["solax_x1"]
+DEPENDENCIES = ["solax_x1_mini"]
 
 CONF_MODE_NAME = "mode_name"
 CONF_ERRORS = "errors"
@@ -15,7 +15,7 @@ ICON_ERRORS = "mdi:alert-circle-outline"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_SOLAX_X1_ID): cv.use_id(SolaxX1),
+        cv.GenerateID(CONF__SOLAX_X1_MINI_ID): cv.use_id(SolaxX1Mini),
         cv.Optional(CONF_MODE_NAME): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    hub = await cg.get_variable(config[CONF_SOLAX_X1_ID])
+    hub = await cg.get_variable(config[CONF__SOLAX_X1_MINI_ID])
     for key in [CONF_MODE_NAME, CONF_ERRORS]:
         if key in config:
             conf = config[key]

--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: solar-powermeter
   device_description: "Monitor multiple Solax X1 mini via RS485"
-  external_components_source: github://syssi/esphome-modbus-solax-x1@main
+  external_components_source: github://syssi/esphome-solax-x1-mini@main
   device0: firstfloor-solar-powermeter
   device1: groundfloor-solar-powermeter
   device2: community-solar-powermeter
@@ -10,7 +10,7 @@ esphome:
   name: ${name}
   comment: ${device_description}
   project:
-    name: "syssi.esphome-modbus-solax-x1"
+    name: "syssi.esphome-solax-x1-mini"
     version: 1.2.1
 
 esp32:
@@ -64,7 +64,7 @@ solax_modbus:
   - id: modbus2
     uart_id: uart2
 
-solax_x1:
+solax_x1_mini:
   - id: solax0
     solax_modbus_id: modbus0
     update_interval: 2s
@@ -76,30 +76,30 @@ solax_x1:
     update_interval: 2s
 
 text_sensor:
-  - platform: solax_x1
-    solax_x1_id: solax0
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax0
     mode_name:
       name: "${device0} mode name"
     errors:
       name: "${device0} errors"
 
-  - platform: solax_x1
-    solax_x1_id: solax1
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax1
     mode_name:
       name: "${device1} mode name"
     errors:
       name: "${device1} errors"
 
-  - platform: solax_x1
-    solax_x1_id: solax2
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax2
     mode_name:
       name: "${device2} mode name"
     errors:
       name: "${device2} errors"
 
 sensor:
-  - platform: solax_x1
-    solax_x1_id: solax0
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax0
     ac_power:
       name: "${device0} ac power"
     energy_today:
@@ -139,8 +139,8 @@ sensor:
     gfc_fault:
       name: "${device0} gfc fault"
 
-  - platform: solax_x1
-    solax_x1_id: solax1
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax1
     ac_power:
       name: "${device1} ac power"
     energy_today:
@@ -180,8 +180,8 @@ sensor:
     gfc_fault:
       name: "${device1} gfc fault"
 
-  - platform: solax_x1
-    solax_x1_id: solax2
+  - platform: solax_x1_mini
+    solax_x1_mini_id: solax2
     ac_power:
       name: "${device2} ac power"
     energy_today:

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: solar-powermeter
   device_description: "Monitor a Solax X1 mini via RS485"
-  external_components_source: github://syssi/esphome-modbus-solax-x1@main
+  external_components_source: github://syssi/esphome-solax-x1-mini@main
   tx_pin: GPIO16
   rx_pin: GPIO17
 
@@ -9,7 +9,7 @@ esphome:
   name: ${name}
   comment: ${device_description}
   project:
-    name: "syssi.esphome-modbus-solax-x1"
+    name: "syssi.esphome-solax-x1-mini"
     version: 1.2.1
 
 esp32:
@@ -48,19 +48,19 @@ solax_modbus:
     uart_id: uart0
 #    flow_control_pin: GPIO0
 
-solax_x1:
+solax_x1_mini:
   solax_modbus_id: modbus0
   update_interval: 1s
 
 text_sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     mode_name:
       name: "${name} mode name"
     errors:
       name: "${name} errors"
 
 sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     ac_power:
       name: "${name} ac power"
     energy_today:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: solar-powermeter
   device_description: "Monitor a Solax X1 mini via RS485"
-  external_components_source: github://syssi/esphome-modbus-solax-x1@main
+  external_components_source: github://syssi/esphome-solax-x1-mini@main
   tx_pin: GPIO4
   rx_pin: GPIO5
 
@@ -9,7 +9,7 @@ esphome:
   name: ${name}
   comment: ${device_description}
   project:
-    name: "syssi.esphome-modbus-solax-x1"
+    name: "syssi.esphome-solax-x1-mini"
     version: 1.2.1
 
 esp8266:
@@ -48,19 +48,19 @@ solax_modbus:
     uart_id: uart0
 #    flow_control_pin: GPIO0
 
-solax_x1:
+solax_x1_mini:
   solax_modbus_id: modbus0
   update_interval: 1s
 
 text_sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     mode_name:
       name: "${name} mode name"
     errors:
       name: "${name} errors"
 
 sensor:
-  - platform: solax_x1
+  - platform: solax_x1_mini
     ac_power:
       name: "${name} ac power"
     energy_today:


### PR DESCRIPTION
Search and replace: `solax_x1:` -> `solax_x1_mini:`
Search and replace: `platform: solax_x1` -> `platform: solax_x1_mini`
