### PR TITLE
Rename uart0 to uart_0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ logger:
   level: DEBUG
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: GPIO4
   rx_pin: GPIO5

--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -44,11 +44,11 @@ mqtt:
 # api:
 
 uart:
-  - id: uart0
+  - id: uart_0
     baud_rate: 9600
     tx_pin: GPIO1
     rx_pin: GPIO3
-  - id: uart1
+  - id: uart_1
     baud_rate: 9600
     tx_pin: GPIO14
     rx_pin: GPIO4
@@ -59,9 +59,9 @@ uart:
 
 solax_modbus:
   - id: modbus0
-    uart_id: uart0
+    uart_id: uart_0
   - id: modbus1
-    uart_id: uart1
+    uart_id: uart_1
   - id: modbus2
     uart_id: uart2
 

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -39,14 +39,14 @@ mqtt:
 # api:
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}
 
 solax_modbus:
   - id: modbus0
-    uart_id: uart0
+    uart_id: uart_0
 #    flow_control_pin: GPIO0
 
 solax_x1_mini:

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -39,14 +39,14 @@ mqtt:
 # api:
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}
 
 solax_modbus:
   - id: modbus0
-    uart_id: uart0
+    uart_id: uart_0
 #    flow_control_pin: GPIO0
 
 solax_x1_mini:

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -39,7 +39,7 @@ mqtt:
   id: mqtt_client
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}
@@ -48,7 +48,7 @@ uart:
 
 solax_meter_modbus:
   - id: modbus0
-    uart_id: uart0
+    uart_id: uart_0
 #    flow_control_pin: GPIO0
 
 solax_meter_gateway:

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -22,7 +22,7 @@ api:
   reboot_timeout: 0s
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}

--- a/tests/esp8266-query-sdm230-floats.yaml
+++ b/tests/esp8266-query-sdm230-floats.yaml
@@ -22,7 +22,7 @@ api:
   reboot_timeout: 0s
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}

--- a/tests/esp8266-query-sdm230.yaml
+++ b/tests/esp8266-query-sdm230.yaml
@@ -22,7 +22,7 @@ api:
   reboot_timeout: 0s
 
 uart:
-  id: uart0
+  id: uart_0
   baud_rate: 9600
   tx_pin: ${tx_pin}
   rx_pin: ${rx_pin}


### PR DESCRIPTION
This change is required by ESPHome 2023.4.0

See https://github.com/esphome/esphome/pull/4446